### PR TITLE
Fix: Add key verification for file deletion

### DIFF
--- a/app/recieve/page.tsx
+++ b/app/recieve/page.tsx
@@ -50,8 +50,12 @@ const page = () => {
       window.URL.revokeObjectURL(url);
 
     } else if (reqType == "delete") {
-      if(res.ok) alert("File deleted successfully!");
-      else alert("Operation Failed. Could not delete File");
+      if(res.ok) {
+        alert("File deleted successfully!");
+      } else {
+        const errorMsg = await res.text();
+        alert(errorMsg || "Operation Failed. Could not delete File");
+      }
     } else {
       alert("Something went wrong. Try again");
     }


### PR DESCRIPTION
Fixes #6

**Security Fix:**
    - Files can now only be deleted by users with the correct encryption key
    - Prevents deletion by anyone who only knows the File ID
     
**Changes:**
    - Added key hashing and verification before deletion (matches download handler pattern)
    - Improved frontend error handling to show specific error messages
    - Key verification uses same pattern as download handler for consistency
     
**Testing:**
    - Tested with correct key (succeeds)
    - Tested with wrong key (returns "Invalid Key" error)
    - Verified error messages are displayed correctly